### PR TITLE
Minor export simplification

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,9 +4,6 @@ module.exports = {
   "collectCoverageFrom": [
     "projects/ngui-common/src/lib/**/src/*.{component,directive,service,pipe}.ts"
   ],
-  "coveragePathIgnorePatterns": [
-      ".module.ts"
-  ],
   "coverageReporters": [
     "text",
     "html"

--- a/projects/ngui-common/src/lib/ngui-common.module.ts
+++ b/projects/ngui-common/src/lib/ngui-common.module.ts
@@ -17,8 +17,3 @@ import {NguiUtilsModule} from './ngui-utils/ngui-utils.module';
 })
 export class NguiCommonModule {
 }
-
-export * from './ngui-inview/ngui-inview.module';
-export * from './ngui-list/ngui-list.module';
-export * from './ngui-utils/ngui-utils.module';
-export * from './ngui-utils/ngui-utils.module';

--- a/projects/ngui-common/src/lib/ngui-inview/ngui-inview.module.ts
+++ b/projects/ngui-common/src/lib/ngui-inview/ngui-inview.module.ts
@@ -3,6 +3,8 @@ import {CommonModule} from '@angular/common';
 import {NguiInviewComponent} from './src/ngui-inview.component';
 import {NguiInviewDirective} from './src/ngui-inview.directive';
 
+export {NguiInviewComponent, NguiInviewDirective};
+
 @NgModule({
     imports: [
         CommonModule
@@ -18,6 +20,3 @@ import {NguiInviewDirective} from './src/ngui-inview.directive';
 })
 export class NguiInviewModule {
 }
-
-export {NguiInviewComponent} from './src/ngui-inview.component';
-export {NguiInviewDirective} from './src/ngui-inview.directive';

--- a/projects/ngui-common/src/lib/ngui-list/ngui-list.module.ts
+++ b/projects/ngui-common/src/lib/ngui-list/ngui-list.module.ts
@@ -7,6 +7,8 @@ import {NguiInviewPageComponent} from './src/ngui-inview-page.component';
 import {NguiVirtualListComponent} from './src/ngui-virtual-list.component';
 import {NguiInviewModule} from '../ngui-inview/ngui-inview.module';
 
+export {NguiAutocompleteComponent, NguiListItemDirective, NguiListDirective, NguiInviewPageComponent, NguiVirtualListComponent};
+
 @NgModule({
     imports: [
         CommonModule,
@@ -30,9 +32,3 @@ import {NguiInviewModule} from '../ngui-inview/ngui-inview.module';
 })
 export class NguiListModule {
 }
-
-export {NguiAutocompleteComponent} from './src/ngui-autocomplete.component';
-export {NguiListItemDirective} from './src/ngui-list-item.directive';
-export {NguiListDirective} from './src/ngui-list.directive';
-export {NguiInviewPageComponent} from './src/ngui-inview-page.component';
-export {NguiVirtualListComponent} from './src/ngui-virtual-list.component';

--- a/projects/ngui-common/src/lib/ngui-utils/ngui-utils.module.ts
+++ b/projects/ngui-common/src/lib/ngui-utils/ngui-utils.module.ts
@@ -2,6 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {NguiHighlightPipe} from './src/ngui-highlight.pipe';
 import {DynamicComponentService} from './src/dynamic-component.service';
+import { konsole } from './src/konsole';
+import { fireEvent } from './src/fire-event';
+
+export {DynamicComponentService, NguiHighlightPipe, konsole, fireEvent};
 
 @NgModule({
   imports: [
@@ -12,8 +16,3 @@ import {DynamicComponentService} from './src/dynamic-component.service';
     providers: [DynamicComponentService]
 })
 export class NguiUtilsModule { }
-
-export { konsole } from './src/konsole';
-export { fireEvent } from './src/fire-event';
-export {DynamicComponentService} from './src/dynamic-component.service';
-export {NguiHighlightPipe} from './src/ngui-highlight.pipe';

--- a/projects/ngui-common/src/public_api.ts
+++ b/projects/ngui-common/src/public_api.ts
@@ -2,4 +2,7 @@
  * Public API Surface of ngui-common
  */
 
+export * from './lib/ngui-inview/ngui-inview.module';
+export * from './lib/ngui-list/ngui-list.module';
+export * from './lib/ngui-utils/ngui-utils.module';
 export * from './lib/ngui-common.module';


### PR DESCRIPTION
Simplified the way components, directives and services are exported from library modules which also fixes duplicates in jest coverage report.